### PR TITLE
型エラー解決

### DIFF
--- a/src/types/league.ts
+++ b/src/types/league.ts
@@ -1,6 +1,6 @@
 export interface League {
   id?: string;
-  createdAt: string;
+  createdAt?: string;
   name: string;
   manual: string;
   rule: LeagueRule;


### PR DESCRIPTION
# 概要
ビルドエラーが発生
league createAtはform登録時に存在しないため
