### PR TITLE
テーブルレイアウト修正/ボタンの色変更

### DIFF
--- a/src/components/buttons/MUIThemeSwitch.tsx
+++ b/src/components/buttons/MUIThemeSwitch.tsx
@@ -26,7 +26,7 @@ export const MUIThemeSwitch = styled(Switch)(({ theme }) => ({
     },
   },
   '& .MuiSwitch-thumb': {
-    backgroundColor: '#001e3c',
+    backgroundColor: theme.palette.secondary.main,
     width: 32,
     height: 32,
     '&::before': {
@@ -43,7 +43,7 @@ export const MUIThemeSwitch = styled(Switch)(({ theme }) => ({
       )}" d="M9.305 1.667V3.75h1.389V1.667h-1.39zm-4.707 1.95l-.982.982L5.09 6.072l.982-.982-1.473-1.473zm10.802 0L13.927 5.09l.982.982 1.473-1.473-.982-.982zM10 5.139a4.872 4.872 0 00-4.862 4.86A4.872 4.872 0 0010 14.862 4.872 4.872 0 0014.86 10 4.872 4.872 0 0010 5.139zm0 1.389A3.462 3.462 0 0113.471 10a3.462 3.462 0 01-3.473 3.472A3.462 3.462 0 016.527 10 3.462 3.462 0 0110 6.528zM1.665 9.305v1.39h2.083v-1.39H1.666zm14.583 0v1.39h2.084v-1.39h-2.084zM5.09 13.928L3.616 15.4l.982.982 1.473-1.473-.982-.982zm9.82 0l-.982.982 1.473 1.473.982-.982-1.473-1.473zM9.305 16.25v2.083h1.389V16.25h-1.39z"/></svg>')`,
     },
     ...theme.applyStyles('dark', {
-      backgroundColor: '#003892',
+      backgroundColor: theme.palette.secondary.main,
     }),
   },
   '& .MuiSwitch-track': {

--- a/src/components/forms/GameForm.tsx
+++ b/src/components/forms/GameForm.tsx
@@ -201,7 +201,7 @@ export const GameForm = (props: {
         <Typography component="p" color="error">
           {validateErorrMsg}
         </Typography>
-        <Button variant="contained" type="submit">
+        <Button variant="contained" type="submit" color="secondary">
           送信
         </Button>
       </Stack>

--- a/src/components/forms/LeagueForm.tsx
+++ b/src/components/forms/LeagueForm.tsx
@@ -428,7 +428,7 @@ export default function LeagueForm(props: { submit: (formdata: LeagueFormData) =
         {validateErorrMsg}
       </Typography>
 
-      <Button variant="contained" type="submit" disabled={!isValid}>
+      <Button variant="contained" type="submit" color="secondary" disabled={!isValid}>
         送信
       </Button>
     </Stack>

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,6 +1,6 @@
 import { Outlet, ScrollRestoration } from 'react-router-dom';
 import { Suspense } from 'react';
-import { Container, Box } from '@mui/material';
+import { Container, Box, Stack } from '@mui/material';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { Header, Footer } from './index';
 import { useRecoilValue } from 'recoil';
@@ -11,11 +11,13 @@ export const AppLayout = () => {
   return (
     <>
       <Header />
-      <Box sx={{ position: 'relative', minHeight: '80vh' }}>
-        {loading && <LoadingSpinner />}
-        <Outlet />
-      </Box>
-      <Footer />
+      <Stack sx={{ minHeight: '100vh' }}>
+        <Box sx={{ flex: 1, position: 'relative' }}>
+          {loading && <LoadingSpinner />}
+          <Outlet />
+        </Box>
+        <Footer />
+      </Stack>
     </>
   );
 };

--- a/src/components/tables/GameRow.tsx
+++ b/src/components/tables/GameRow.tsx
@@ -1,15 +1,8 @@
-import {
-  Box,
-  IconButton,
-  Table,
-  TableBody,
-  TableCell,
-  TableCellProps,
-  TableHead,
-  TableRow,
-} from '@mui/material';
-import { Game } from '../../types/game';
+import { Box, IconButton, TableCell, TableCellProps, TableRow } from '@mui/material';
+import { Game, GameResult } from '../../types/game';
 import { dateFormat } from '../../utils/date';
+import { TableContainer } from './TableContainer';
+import { Column } from '../../types/common';
 
 export const GameRow = (props: {
   row: Game;
@@ -17,6 +10,13 @@ export const GameRow = (props: {
   handleDelete: (id: string) => void;
 }) => {
   const { row, align, handleDelete } = props;
+
+  const resultColumns: Column<GameResult>[] = [
+    { key: 'rank', display: '順位' },
+    { key: 'name', display: '名前' },
+    { key: 'point', display: '点数' },
+    { key: 'calcPoint', display: '順位点' },
+  ];
 
   return (
     <TableRow>
@@ -34,28 +34,16 @@ export const GameRow = (props: {
       </TableCell>
       <TableCell colSpan={4}>
         <Box sx={{ margin: 0 }}>
-          <Table size="small" aria-label="purchases">
-            <TableHead>
-              <TableRow>
-                <TableCell component="th" scope="row">
-                  順位
-                </TableCell>
-                <TableCell align="right">名前</TableCell>
-                <TableCell align="right">点数</TableCell>
-                <TableCell align="right">点数</TableCell>
+          <TableContainer<GameResult> columns={resultColumns} align={align} size="small">
+            {row.results.map((resultRow) => (
+              <TableRow key={resultRow.rank}>
+                <TableCell align={align}>{resultRow.rank}</TableCell>
+                <TableCell align={align}>{resultRow.name}</TableCell>
+                <TableCell align={align}>{resultRow.point}</TableCell>
+                <TableCell align={align}>{resultRow.calcPoint}</TableCell>
               </TableRow>
-            </TableHead>
-            <TableBody>
-              {row.results.map((resultRow) => (
-                <TableRow key={resultRow.rank}>
-                  <TableCell>{resultRow.rank}</TableCell>
-                  <TableCell align="right">{resultRow.name}</TableCell>
-                  <TableCell align="right">{resultRow.point}</TableCell>
-                  <TableCell align="right">{resultRow.calcPoint}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+            ))}
+          </TableContainer>
         </Box>
       </TableCell>
     </TableRow>

--- a/src/components/tables/TableContainer.tsx
+++ b/src/components/tables/TableContainer.tsx
@@ -5,9 +5,9 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  TableSortLabel,
   Paper,
   TableCellProps,
+  TableOwnProps,
 } from '@mui/material';
 import MUITabelContainer from '@mui/material/TableContainer';
 
@@ -15,33 +15,21 @@ import { Column } from '../../types/common';
 
 export const TableContainer = <T,>(props: {
   columns: Column<T>[];
+  size?: TableOwnProps['size'];
   align?: TableCellProps['align'];
-  order?: 'asc' | 'desc';
-  orderBy?: keyof T | null;
+  elevation?: number;
   children: React.ReactNode;
-  handleSort?: (column: keyof T) => void;
 }) => {
-  const { order, orderBy, columns, align, children, handleSort } = props;
+  const { size, elevation, columns, align, children } = props;
 
   return (
-    <MUITabelContainer component={Paper} elevation={1}>
-      <Table>
+    <MUITabelContainer component={elevation ? Paper : 'div'} elevation={elevation}>
+      <Table size={size}>
         <TableHead>
           <TableRow>
             {columns.map((column) => (
-              <TableCell align={align} key={column.key as string}>
-                {handleSort ? (
-                  <TableSortLabel
-                    sx={{ minWidth: '4rem' }}
-                    active={orderBy === column.key}
-                    direction={orderBy === column.key ? order : 'asc'}
-                    onClick={() => handleSort(column.key)}
-                  >
-                    {column.display}
-                  </TableSortLabel>
-                ) : (
-                  column.display
-                )}
+              <TableCell align={align} key={column.key} sx={{ minWidth: '6rem' }}>
+                {column.display}
               </TableCell>
             ))}
           </TableRow>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -42,7 +42,7 @@ export default function Detail() {
   ];
 
   const editColumns: Column<Game>[] = [
-    { key: 'createdAt', display: '対戦日' },
+    { key: 'createdAt', display: '登録日' },
     { key: 'results', display: '試合結果' },
   ];
 
@@ -158,7 +158,11 @@ export default function Detail() {
               </>
 
               {gameResultTotal && (
-                <TableContainer<GameResultTotal> columns={detailColumns} align="center">
+                <TableContainer<GameResultTotal>
+                  columns={detailColumns}
+                  align="center"
+                  elevation={1}
+                >
                   {gameResultTotal.map((row, i) => (
                     <React.Fragment key={i}>
                       <GameTotalRow row={row} align="center" />
@@ -183,7 +187,12 @@ export default function Detail() {
                 </Button>
 
                 {gameResultCreateAtDesc && (
-                  <TableContainer<Game> columns={editColumns} align="center">
+                  <TableContainer<Game>
+                    columns={editColumns}
+                    align="center"
+                    size="small"
+                    elevation={1}
+                  >
                     {gameResultCreateAtDesc.map((row, i) => (
                       <React.Fragment key={i}>
                         <GameRow row={row} align="center" handleDelete={deleteGame} />

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -182,7 +182,7 @@ export default function Detail() {
               </Stack>
 
               <Stack>
-                <Button variant="contained" onClick={handleModalOpen}>
+                <Button variant="contained" color="secondary" onClick={handleModalOpen}>
                   成績登録
                 </Button>
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,4 @@
 export interface Column<T> {
-  key: keyof T;
+  key: Extract<keyof T, string>;
   display: string;
 }


### PR DESCRIPTION
# Issue
#23 #24

# 概要
テーブルのレイアウトを修正
カラムの長さを調整
TableContainerを使用する様に変更
ソート機能は一旦すべての機能を廃止

ボタン要素の色をsecondaryに統一

# 備考
解像度の違うディスプレイでレイアウトが崩れる問題を修正
