### PR TITLE
円グラフの色を順位に応じた色に変更する

### DIFF
--- a/src/features/game/GamePieChart.tsx
+++ b/src/features/game/GamePieChart.tsx
@@ -10,7 +10,6 @@ export const GamePieChart = (props: { name: string }) => {
 
   return (
     <PieChart
-      colors={['#C96868', '#DEAA79', '#B1C29E', '#7EACB5']}
       series={[
         {
           arcLabel: (item) => `${item.value}%`,

--- a/src/features/game/GameRegister.tsx
+++ b/src/features/game/GameRegister.tsx
@@ -1,5 +1,6 @@
 import { ModalContainer } from '@/components/ModalContainer';
 import { LeagueRule } from '@/types/league';
+import { GameFormData } from '@/types/game';
 import { GameForm } from './components/GameForm';
 import { useGameData } from './hooks/useGameData';
 import { useGame } from './hooks/useGame';
@@ -10,9 +11,14 @@ export const GameRegister = (props: { rule: LeagueRule; isOpen: boolean; close: 
   const { playersData } = useGameData();
   const { create } = useGame();
 
+  const submit = (formdata: GameFormData) => {
+    create(formdata);
+    close();
+  };
+
   return (
     <ModalContainer modalTitle="成績登録" isOpen={isOpen} close={close}>
-      <GameForm rule={rule} gamePlayers={playersData} submit={create} />
+      <GameForm rule={rule} gamePlayers={playersData} submit={submit} />
     </ModalContainer>
   );
 };

--- a/src/features/game/jotai/gamePieChartAtom.ts
+++ b/src/features/game/jotai/gamePieChartAtom.ts
@@ -5,6 +5,7 @@ interface GamePieData {
   id: number;
   label: string;
   value: number;
+  color: string;
 }
 
 export const gamePieChartAtom = atom(async (get) => {
@@ -32,10 +33,14 @@ export const gamePieChartAtom = atom(async (get) => {
 
     // トータル対戦数を取得
     const total = resultsByName.length;
+    // 順位に対応する円グラフの色を格納
+    // 順位は常に1〜4の範囲であるため、配列の長さは4に固定
+    const colors = ['#C96868', '#DEAA79', '#B1C29E', '#7EACB5'];
     const pieData: GamePieData[] = rankCountArray.map((entry) => ({
       id: entry.rank,
       label: entry.rank.toString() + '位',
       value: Math.floor((entry.count / total) * 1000) / 10, // 少数点第2位まで
+      color: colors[entry.rank - 1],
     }));
 
     return { name: name, results: pieData.sort((a, b) => a.id - b.id) };


### PR DESCRIPTION
# Issue
#52

# 概要
順位に応じた色を使用する様に変更

変更後の動作の例
1位しかない場合:赤
2位しかない場合:青
2位と3位がある場合:青、黄

# 備考
ゲーム登録時に、モーダルが閉じなくなっていたため修正