### PR TITLE
リリース後に発覚したUI・UXの調整対応

### DIFF
--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -33,7 +33,9 @@ export const PasswordInput = (props: {
           readOnly
           tabIndex={-1}
         />
-        <InputLabel htmlFor="password">パスワード</InputLabel>
+        <InputLabel required htmlFor="password">
+          パスワード
+        </InputLabel>
         <OutlinedInput
           id="password"
           type={showPassword ? 'text' : 'password'}

--- a/src/features/favorite/FavoriteMenu.tsx
+++ b/src/features/favorite/FavoriteMenu.tsx
@@ -21,17 +21,15 @@ export const FavoriteMenu = () => {
       </Button>
       <Menu anchorEl={anchorEl} open={isOpen} onClose={closeMenu} sx={{ width: 150 }}>
         {favoriteList.map((v) => (
-          <MenuItem onClick={closeMenu} key={v.id}>
+          <MenuItem
+            key={v.id}
+            component={Link}
+            to={`/detail/${v.id}`}
+            onClick={closeMenu}
+            sx={{ textDecoration: 'none', color: theme.palette.text.primary }}
+          >
             <Typography variant="inherit" noWrap>
-              <Link
-                to={`/detail/${v.id}`}
-                style={{
-                  textDecoration: 'none',
-                  color: theme.palette.text.primary,
-                }}
-              >
-                {v.name}
-              </Link>
+              {v.name}
             </Typography>
           </MenuItem>
         ))}

--- a/src/features/league/components/LeagueForm.tsx
+++ b/src/features/league/components/LeagueForm.tsx
@@ -205,7 +205,7 @@ export const LeagueForm = (props: { submit: (formdata: LeagueFormData) => void }
       <Controller
         name="manual"
         control={control}
-        render={({ field }) => <TextField {...field} fullWidth label="説明" multiline rows={4} />}
+        render={({ field }) => <TextField {...field} label="説明" />}
       ></Controller>
 
       <Stack>
@@ -232,7 +232,6 @@ export const LeagueForm = (props: { submit: (formdata: LeagueFormData) => void }
       </Stack>
 
       <FormControl>
-        <FormLabel>ルール</FormLabel>
         <RadioGroup row value={selectedRule} onChange={handleRuleChange}>
           <FormControlLabel
             value="M"

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -16,7 +16,10 @@ axiosRetry(apiClient, {
   retryCondition: (error) => {
     const config = error.config;
     if (!config) return false;
+    // 401は認証エラーのため、リトライを行わない
     if (error.response?.status === 401) return false;
+    // GETは、リトライを行わない
+    if (config.method?.toLowerCase() === 'get') return false;
     const isExcludedPath = excludedPaths.some((path) => config.url?.includes(path));
     return !isExcludedPath;
   },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -54,6 +54,24 @@ export const darkTheme = createTheme({
         },
       },
     },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#ffffff',
+          },
+        },
+      },
+    },
+    MuiInputLabel: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused': {
+            color: '#ffffff',
+          },
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
# Issue
#59
# 概要
本番テスト後に、発見したUI・UXの調整対応

- パスワードインプットの必須マーク
- Menuのクリック位置が”文字”の中だけ、クリック可能位置となっていった。
- multiline を使用すると、モバイル端末で表示が崩れる( focus時に、文字が線に被る)
- ダークモード時に、focusすると文字が見えなくなっていたため、focus色の変更
- GETリクエストでエラーの場合、リトライを行わない。(#62を作成し要調整)
-  フォームのラベルとして付けていた”ルール”の挙動がチラつくため、一旦外す(無くても良いかも)

# 備考