### PR TITLE
カスタムルール選択時にパスワードinputが初期化される

### DIFF
--- a/src/features/league/components/LeagueForm.tsx
+++ b/src/features/league/components/LeagueForm.tsx
@@ -150,11 +150,9 @@ export const LeagueForm = (props: { submit: (formdata: LeagueFormData) => void }
     const rule = ruleMap[value];
 
     if (!rule) {
-      const { name, manual } = getValues();
+      const { name, manual, password } = getValues();
       setDisableForm(false);
-      reset();
-      setValue('name', name);
-      setValue('manual', manual);
+      reset({ name, manual, password });
     } else {
       Object.keys(rule).forEach((key) => {
         setValue(key as keyof FormData, rule[key as keyof FormDataRule], {


### PR DESCRIPTION
# Issue
#66 

# 概要
ルール選択時のリセットで、nameとmanualは省いていたが、パスワードは漏れてたため対応
# 備考