### PR TITLE
TOP画像が1980以上で表示が崩れる

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,7 +10,10 @@ export const Home = () => {
       <Box
         sx={{
           width: 1,
-          height: { xs: 'auto', md: 430 },
+          height: { xs: 'auto', md: 450 },
+          '@media (min-width:1980px)': {
+            height: { xs: 'auto', md: 700 },
+          },
           position: 'relative',
         }}
       >


### PR DESCRIPTION
# Issue
#70

# 概要
TOP画像が1980以上で表示が崩れる
mediaqueryで対応